### PR TITLE
feat: create `onboarding` and `plan-selection` features

### DIFF
--- a/.github/workflows/Code_Validation.yaml
+++ b/.github/workflows/Code_Validation.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup Node.js 🌲
         uses: actions/setup-node@v2
       - name: Install Dependencies 📦
-        run: pnpm install
+        run: npm i -g pnpm && pnpm install && pnpm list
       - name: TypeScript Check 📊
         run: pnpm run type-check
       - name: Lint Analytics 🧹

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,14 @@ model UserPlan {
   updatedAt    DateTime @updatedAt
 }
 
+model UserPlanSubscription {
+  id        String   @id @default(uuid())
+  userId    String
+  planId    String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
 // This "WaitList" model is used to store the emails of users who want to be and will to be notified when the app is 
 // ready.
 model WaitList {

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -1,0 +1,45 @@
+import { Fragment } from 'react'
+
+import { type Metadata } from 'next'
+
+import Footer from '@root/components/ui/footer'
+import Onboarding from '@root/features/onboarding/onboarding'
+import createUserPlanRepository from '@root/repositories/user/plan/create-user-plan-repository'
+
+/**
+ * The metadata for the page to remove the page from the search engines.
+ */
+export const metadata: Metadata = {
+  title: 'Onboarding P&P',
+  robots: 'noindex, nofollow',
+}
+
+/**
+ * Fetches the user plans from the {@link createUserPlanRepository | repository}, maps through them and returns a
+ * compact version of the user plans.
+ */
+async function fetchCompactUserPlans() {
+  const repo = createUserPlanRepository()
+  const plans = (await repo.fetchUserPlans()).map(({ id, name, price, highlights }) => ({
+    id,
+    name,
+    price,
+    highlights,
+  }))
+  return plans
+}
+
+async function OnboardingPage(): Promise<JSX.Element> {
+  const plans = await fetchCompactUserPlans()
+
+  return (
+    <Fragment>
+      <main className='container mt-20 min-h-[90vh]'>
+        <Onboarding plans={plans} />
+      </main>
+      <Footer />
+    </Fragment>
+  )
+}
+
+export default OnboardingPage

--- a/src/features/onboarding/onboarding.tsx
+++ b/src/features/onboarding/onboarding.tsx
@@ -1,0 +1,63 @@
+import Link from 'next/link'
+
+import Heading from '@root/components/ui/heading'
+import Logo from '@root/components/ui/logo'
+import Paragraph from '@root/components/ui/paragraph'
+
+import SelectionPlansRow from '../plan-selection/components/selection-plans-row'
+import SelectionSubmitButton from '../plan-selection/components/selection-submit-button'
+
+/**
+ * Props for the {@link Onboarding} component.
+ */
+interface OnboardingProps {
+  /**
+   * The plans to display.
+   */
+  plans: {
+    id: string
+    name: string
+    price: string
+    highlights: string[]
+  }[]
+}
+
+/**
+ * The onboarding feature component that aggregates the plan selection and the user information form.
+ *
+ * @props {@link OnboardingProps}
+ */
+function Onboarding({ plans }: OnboardingProps): JSX.Element {
+  return (
+    <div className='container flex flex-col items-center justify-center gap-16'>
+      <Logo isAnimated={true} className='cursor-default select-none' />
+      <div className='flex flex-col items-center justify-center gap-1'>
+        <Heading hierarchy='h1'>Select a plan</Heading>
+        <Heading hierarchy='h2' className='text-base font-normal text-gray-500'>
+          No credit card. 30-day money-back guarantee. Cancel anytime.
+        </Heading>
+      </div>
+      <SelectionPlansRow plans={plans} />
+      <SelectionSubmitButton />
+      <div>
+        <Paragraph className='text-center text-foreground/70'>
+          Under the hood, we use{' '}
+          <Link href='https://www.stripe.com' className='font-medium'>
+            Stripe
+          </Link>
+          &nbsp;to process your payments. That means&nbsp;
+          <b>quick</b>, <b>easy</b> and <b>secure</b> payments.
+        </Paragraph>
+        <Paragraph className='text-center text-foreground/70'>
+          Learn more about Stripe&apos;s privacy policy&nbsp;
+          <Link href='https://stripe.com/en-gb/privacy' className='underline'>
+            here
+          </Link>
+          .
+        </Paragraph>
+      </div>
+    </div>
+  )
+}
+
+export default Onboarding

--- a/src/features/plan-selection/components/selection-card.tsx
+++ b/src/features/plan-selection/components/selection-card.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { type HTMLAttributes } from 'react'
+
+import { cva } from 'class-variance-authority'
+import { motion } from 'framer-motion'
+
+import merge from '@root/util/merge'
+
+const selectionCard = cva(
+  'flex flex-col items-center justify-center hover:from-purple-700 hover:to-indigo-700 hover:bg-gradient-to-bl transition-all',
+  {
+    variants: {
+      variant: {
+        unset: 'bg-background text-foreground',
+        selected: 'from-purple-700 to-indigo-700 bg-gradient-to-bl text-white',
+      },
+    },
+  },
+)
+
+/**
+ * Props for the {@link SelectionCard} component.
+ */
+interface SelectionCardProps extends Pick<HTMLAttributes<HTMLElement>, 'children' | 'className' | 'onClick'> {
+  /**
+   * Boolean indicating whether the card is selected.
+   */
+  isSelected: boolean
+}
+
+/**
+ * A card that can be selected.
+ *
+ * @props {@link SelectionCardProps}
+ */
+function SelectionCard({ isSelected, children, className, onClick }: SelectionCardProps): JSX.Element {
+  const variant = isSelected ? 'selected' : 'unset'
+
+  return (
+    <motion.button
+      onClick={onClick}
+      type='button'
+      className={merge(
+        'h-96 w-full rounded-xl border border-gray-500/50 p-4 transition-all hover:bg-gradient-to-bl',
+        selectionCard({ variant, className }),
+      )}
+      whileHover={{ scale: 1.05 }}
+      whileTap={{ scale: 0.8 }}
+    >
+      {children}
+    </motion.button>
+  )
+}
+
+export default SelectionCard

--- a/src/features/plan-selection/components/selection-plans-row.tsx
+++ b/src/features/plan-selection/components/selection-plans-row.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useCallback, type MouseEvent as ReactMouseEvent } from 'react'
+
+import { usePathname, useRouter, useSearchParams } from 'next/navigation'
+
+import merge from '@root/util/merge'
+
+import PlanSelectionQueryParams from '../constants/plan-selection-query-params'
+
+import SelectionCard from './selection-card'
+
+/**
+ * Props for the {@link Onboarding} component.
+ */
+interface SelectionPlansRowProps {
+  /**
+   * The plans to display.
+   */
+  plans: {
+    id: string
+    name: string
+    price: string
+    highlights: string[]
+  }[]
+}
+
+function SelectionPlansRow({ plans }: SelectionPlansRowProps): JSX.Element {
+  const pathname = usePathname()
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  const selectedPlanId = searchParams.get(PlanSelectionQueryParams.selectedPlanId)
+
+  const handleSelectPlan = useCallback(
+    (planId: string, isSelected: boolean) => (_event: ReactMouseEvent<HTMLElement>) => {
+      if (isSelected) {
+        return
+      }
+      const newSearchParams = new URLSearchParams(searchParams)
+      newSearchParams.set(PlanSelectionQueryParams.selectedPlanId, planId)
+
+      const href = `${pathname}?${newSearchParams.toString()}`
+      router.push(href)
+    },
+    [pathname, router, searchParams],
+  )
+
+  return (
+    <div className='container flex flex-1 flex-col items-center gap-6 shadow-xl lg:flex-row'>
+      {plans.map(({ id, name, price, highlights }) => {
+        const isSelected = selectedPlanId === id
+        return (
+          <SelectionCard key={id} isSelected={isSelected} onClick={handleSelectPlan(id, isSelected)} className='gap-4'>
+            <span className='text-2xl font-bold'>{name}</span>
+            <span>
+              <span className='text-sm font-medium'>$</span>
+              <span className={merge(isSelected ? 'text-white' : 'text-foreground', 'text-2xl font-semibold')}>
+                {price}
+              </span>
+              <span className='text-sm font-medium'>USD</span>
+            </span>
+            <ul>
+              {highlights.map((highlight) => (
+                <li key={highlight} className='flex items-center gap-2'>
+                  <span className='text-lg font-medium'>✓</span>
+                  <span className='text-base' dangerouslySetInnerHTML={{ __html: highlight }} />
+                </li>
+              ))}
+            </ul>
+          </SelectionCard>
+        )
+      })}
+    </div>
+  )
+}
+
+export default SelectionPlansRow

--- a/src/features/plan-selection/components/selection-submit-button.tsx
+++ b/src/features/plan-selection/components/selection-submit-button.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { AnimatePresence, motion } from 'framer-motion'
+import { useSearchParams } from 'next/navigation'
+
+import Button from '@root/components/ui/button'
+
+import PlanSelectionFormField from '../constants/plan-selection-form-field'
+import PlanSelectionQueryParams from '../constants/plan-selection-query-params'
+import subscribeToPlanAction from '../server-actions/subscribe-to-plan-action'
+
+/**
+ * The animation for the button container.
+ */
+const buttonContainerAnimation = {
+  initial: {
+    opacity: 0,
+    y: 20,
+  },
+  animate: {
+    opacity: 1,
+    y: 0,
+  },
+}
+
+/**
+ * The submit button for the plan selection form.
+ */
+function SelectionSubmitButton(): JSX.Element {
+  const searchParams = useSearchParams()
+
+  const selectedPlanId = searchParams.get(PlanSelectionQueryParams.selectedPlanId) ?? undefined
+  const isPlanSelected = !!selectedPlanId
+
+  return (
+    <form action={subscribeToPlanAction}>
+      <input name={PlanSelectionFormField.selectedPlan} className='hidden' defaultValue={selectedPlanId} />
+      <AnimatePresence>
+        {isPlanSelected && (
+          <motion.div
+            initial={buttonContainerAnimation.initial}
+            animate={buttonContainerAnimation.animate}
+            exit={buttonContainerAnimation.initial}
+          >
+            <Button type='submit'>Continue</Button>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </form>
+  )
+}
+
+export default SelectionSubmitButton

--- a/src/features/plan-selection/constants/plan-selection-form-field.ts
+++ b/src/features/plan-selection/constants/plan-selection-form-field.ts
@@ -1,0 +1,5 @@
+const PlanSelectionFormField = {
+  selectedPlan: 'selected_plan',
+} as const
+
+export default PlanSelectionFormField

--- a/src/features/plan-selection/constants/plan-selection-query-params.ts
+++ b/src/features/plan-selection/constants/plan-selection-query-params.ts
@@ -1,0 +1,5 @@
+const PlanSelectionQueryParams = {
+  selectedPlanId: 'p',
+} as const
+
+export default PlanSelectionQueryParams

--- a/src/features/plan-selection/plan-selection.tsx
+++ b/src/features/plan-selection/plan-selection.tsx
@@ -1,0 +1,17 @@
+import { type ComponentPropsWithoutRef } from 'react'
+
+import SelectionPlansRow from './components/selection-plans-row'
+
+interface PlanSelectionProps extends Pick<ComponentPropsWithoutRef<typeof SelectionPlansRow>, 'plans'> {
+  className?: string
+}
+
+function PlanSelection({ className, plans }: PlanSelectionProps): JSX.Element {
+  return (
+    <div className={className}>
+      <SelectionPlansRow plans={plans} />
+    </div>
+  )
+}
+
+export default PlanSelection

--- a/src/features/plan-selection/server-actions/subscribe-to-plan-action.ts
+++ b/src/features/plan-selection/server-actions/subscribe-to-plan-action.ts
@@ -1,0 +1,33 @@
+import { redirectToSignIn } from '@clerk/nextjs/server'
+import { redirect } from 'next/navigation'
+
+import createAuthRepository from '@root/repositories/auth/create-auth-repository'
+import createUserPlanRepository from '@root/repositories/user/plan/create-user-plan-repository'
+
+import PlanSelectionFormField from '../constants/plan-selection-form-field'
+
+const auth = createAuthRepository()
+const userPlans = createUserPlanRepository()
+
+export default async function subscribeToPlanAction(values: FormData) {
+  const user = await auth.currentUser()
+
+  if (!user) {
+    return redirectToSignIn({ returnBackUrl: '/onboarding' })
+  }
+
+  const userId = user.uid
+  const planId = values.get(PlanSelectionFormField.selectedPlan)?.toString()
+
+  if (!planId) {
+    return
+  }
+
+  try {
+    await userPlans.subscribeUserToPlan(userId, planId)
+
+    redirect('/onboarding?success=true')
+  } catch (error) {
+    console.log(`Error subscribing user to plan: ${error}`)
+  }
+}

--- a/src/repositories/_/prisma/prisma-user-plan-repository.ts
+++ b/src/repositories/_/prisma/prisma-user-plan-repository.ts
@@ -1,11 +1,36 @@
-import { type UserPlan } from '@prisma/client'
+import { type UserPlanSubscription, type UserPlan } from '@prisma/client'
 
 import UserPlanRepository from '@root/repositories/user/plan/user-plan-repository'
 import UserPlanNotFoundException from '@root/repositories/user/plan/user-plan-not-found-exception'
 import PrismaService from '@root/services/prisma-service'
+import UserPlanSubscriptionNotFoundException from '@root/repositories/user/plan/user-plan-subscription-not-found-exception'
 
 class PrismaUserPlanRepository extends UserPlanRepository {
   private readonly PRISMA_CLIENT = PrismaService.client()
+
+  async fetchUserSubscriptionByUserId(userId: string): Promise<UserPlanSubscription> {
+    const userPlanSubscription = await this.PRISMA_CLIENT.userPlanSubscription.findFirst({
+      where: {
+        userId,
+      },
+    })
+
+    if (!userPlanSubscription) {
+      throw new UserPlanSubscriptionNotFoundException(userId)
+    }
+
+    return userPlanSubscription
+  }
+  async subscribeUserToPlan(userId: string, planId: string): Promise<UserPlanSubscription> {
+    const userPlanSubscription = await this.PRISMA_CLIENT.userPlanSubscription.create({
+      data: {
+        userId,
+        planId,
+      },
+    })
+
+    return userPlanSubscription
+  }
 
   async fetchUserPlans(): Promise<UserPlan[]> {
     const userPlans = await this.PRISMA_CLIENT.userPlan.findMany()

--- a/src/repositories/auth/current-user-result.ts
+++ b/src/repositories/auth/current-user-result.ts
@@ -28,6 +28,19 @@ interface CurrentUserResult {
    * The JWT token that can be used to authenticate the user in future requests.
    */
   token: string
+  /**
+   * Boolean that indicates whether or not the user has enabled two-factor authentication.
+   */
+  isTwoFactorAuthenticationEnabled: boolean
+  /**
+   * The username of the user. This is the value used as an option to sign in to the user's account instead of an
+   * {@link email | e-mail} address.
+   */
+  username?: string
+  /**
+   * The timestamp in milliseconds since the epoch that represents the last time the user signed in.
+   */
+  lastSignInAt?: number
 }
 
 export default CurrentUserResult

--- a/src/repositories/user/plan/user-plan-repository.ts
+++ b/src/repositories/user/plan/user-plan-repository.ts
@@ -1,4 +1,4 @@
-import { type UserPlan } from '@prisma/client'
+import { type UserPlan, type UserPlanSubscription } from '@prisma/client'
 
 abstract class UserPlanRepository {
   /**
@@ -11,6 +11,18 @@ abstract class UserPlanRepository {
    * Fetches the list of {@link UserPlan | user plans} of the user with the given id and returns the list of user plans.
    */
   abstract fetchUserPlans(): Promise<UserPlan[]>
+  /**
+   * Fetches the {@link UserPlanSubscription | user plan subscription} of the user with the given {@link userId} and
+   * returns the object with the user plan subscription.
+   *
+   * @see {@link UserPlanSubscription}
+   */
+  abstract fetchUserSubscriptionByUserId(userId: string): Promise<UserPlanSubscription>
+  /**
+   * Subscribes the user with the given {@link userId} to the plan with the given {@link planId} and returns the
+   * {@link UserPlanSubscription | user plan subscription} object.
+   */
+  abstract subscribeUserToPlan(userId: string, planId: string): Promise<UserPlanSubscription>
 }
 
 export default UserPlanRepository

--- a/src/repositories/user/plan/user-plan-subscription-not-found-exception.ts
+++ b/src/repositories/user/plan/user-plan-subscription-not-found-exception.ts
@@ -1,0 +1,5 @@
+export default class UserPlanSubscriptionNotFoundException extends Error {
+  constructor(userId: string) {
+    super(`UserPlanSubscription could not be found with the given userId "${userId}".`)
+  }
+}

--- a/src/repositories/wait-list/create-wait-list-repository.ts
+++ b/src/repositories/wait-list/create-wait-list-repository.ts
@@ -1,5 +1,3 @@
-import { PrismaClient } from '@prisma/client'
-
 import WaitListRepository from './wait-list-repository'
 import PrismaWaitListRepository from '../_/prisma/prisma-wait-list-repository'
 
@@ -7,9 +5,7 @@ import PrismaWaitListRepository from '../_/prisma/prisma-wait-list-repository'
  * Creates an instance of {@link WaitListRepository} and returns it.
  */
 function createWaitListRepository(): WaitListRepository {
-  const prismaClient = new PrismaClient()
-
-  return new PrismaWaitListRepository(prismaClient)
+  return new PrismaWaitListRepository()
 }
 
 export default createWaitListRepository


### PR DESCRIPTION
Create the **Onboarding** and **Plan Selection** that is rendered after the user signs up.

![Screenshot 2023-11-23 at 1 29 47 am](https://github.com/mrlemoos/party-planner/assets/69330304/6adea18f-6e50-4d4e-8590-05687253f24a)

This file also changes the `prisma/schema.prisma` file to add the `UserPlanSubscription` model.